### PR TITLE
Remove the use of Shared from the public API to avoid consumers being required to use unsafe to use the map

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,8 +177,6 @@ where
 
     pub fn get_and<R, F: FnOnce(&V) -> R>(&self, key: &K, then: F) -> Option<R> {
         let guard = &crossbeam::epoch::pin();
-        // safety: we are still holding the guard, and saw `v`, so it won't be dropped until the
-        // next epoch after we drop our guard at the earliest.
         self.get(key, guard).map(then)
     }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -33,8 +33,7 @@ fn insert_and_get() {
     {
         let guard = epoch::pin();
         let e = map.get(&42, &guard).unwrap();
-        // safety: the map guarantees that it will not free something there is a Shared to
-        assert_eq!(unsafe { e.deref() }, &0);
+        assert_eq!(e, &0);
     }
 }
 
@@ -48,8 +47,7 @@ fn update() {
     {
         let guard = epoch::pin();
         let e = map.get(&42, &guard).unwrap();
-        // safety: the map guarantees that it will not free something there is a Shared to
-        assert_eq!(unsafe { e.deref() }, &1);
+        assert_eq!(e, &1);
     }
 }
 
@@ -75,9 +73,7 @@ fn concurrent_insert() {
 
     let guard = epoch::pin();
     for i in 0..64 {
-        let e = map.get(&i, &guard).unwrap();
-        // safety: the map guarantees that it will not free something there is a Shared to
-        let v = unsafe { e.deref() };
+        let v = map.get(&i, &guard).unwrap();
         assert!(v == &0 || v == &1);
     }
 }


### PR DESCRIPTION
My expectation is that a regular user of the map should not be required to use `unsafe`. `Shared` requires that you use unsafe to dereference to the value. Instead, tie the reference to the lifetime of the guard passed into the get method