### PR TITLE
Add iter, keys, and values with Java tests

### DIFF
--- a/src/iter/iter.rs
+++ b/src/iter/iter.rs
@@ -1,0 +1,122 @@
+use crossbeam::epoch::Guard;
+use std::sync::atomic::Ordering;
+
+use crate::NodeIter;
+
+/// An iterator over the entries of a `FlurryHashMap`.
+///
+/// This `struct` is created by the [`iter`] method on [`FlurryHashMap`].
+/// See its documentation for more.
+///
+/// [`iter`]: /flurry/struct.FlurryHashMap.html#method.iter
+/// [`FlurryHashMap`]: /flurry/struct.FlurryHashMap.html
+#[derive(Debug)]
+pub struct Iter<'g, K, V> {
+    pub(crate) node_iter: NodeIter<'g, K, V>,
+    pub(crate) guard: &'g Guard,
+}
+
+impl<'g, K, V> Iterator for Iter<'g, K, V> {
+    type Item = (&'g K, &'g V);
+    fn next(&mut self) -> Option<Self::Item> {
+        let node = self.node_iter.next()?;
+        let value = node.value.load(Ordering::SeqCst, self.guard);
+        // safety: flurry does not drop or move until after guard drop
+        let value = unsafe { value.deref() };
+        return Some((&node.key, &value));
+    }
+}
+
+/// An iterator over the keys of a `FlurryHashMap`.
+///
+/// This `struct` is created by the [`keys`] method on [`FlurryHashMap`].
+/// See its documentation for more.
+///
+/// [`keys`]: /flurry/struct.FlurryHashMap.html#method.keys
+/// [`FlurryHashMap`]: /flurry/struct.FlurryHashMap.html
+#[derive(Debug)]
+pub struct Keys<'g, K, V> {
+    pub(crate) node_iter: NodeIter<'g, K, V>,
+}
+
+impl<'g, K, V> Iterator for Keys<'g, K, V> {
+    type Item = &'g K;
+    fn next(&mut self) -> Option<Self::Item> {
+        let node = self.node_iter.next()?;
+        return Some(&node.key);
+    }
+}
+
+/// An iterator over the values of a `FlurryHashMap`.
+///
+/// This `struct` is created by the [`values`] method on [`FlurryHashMap`].
+/// See its documentation for more.
+///
+/// [`values`]: /flurry/struct.FlurryHashMap.html#method.values
+/// [`FlurryHashMap`]: /flurry/struct.FlurryHashMap.html
+#[derive(Debug)]
+pub struct Values<'g, K, V> {
+    pub(crate) node_iter: NodeIter<'g, K, V>,
+    pub(crate) guard: &'g Guard,
+}
+
+impl<'g, K, V> Iterator for Values<'g, K, V> {
+    type Item = &'g V;
+    fn next(&mut self) -> Option<Self::Item> {
+        let node = self.node_iter.next()?;
+        let value = node.value.load(Ordering::SeqCst, self.guard);
+        // safety: flurry does not drop or move until after guard drop
+        let value = unsafe { value.deref() };
+        return Some(&value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::FlurryHashMap;
+    use crossbeam::epoch::{self};
+    use std::collections::HashSet;
+    use std::iter::FromIterator;
+
+    #[test]
+    fn iter() {
+        let map = FlurryHashMap::<usize, usize>::new();
+
+        map.insert(1, 42);
+        map.insert(2, 84);
+
+        let guard = epoch::pin();
+        assert_eq!(
+            map.iter(&guard).collect::<HashSet<(&usize, &usize)>>(),
+            HashSet::from_iter(vec![(&1, &42), (&2, &84)])
+        );
+    }
+
+    #[test]
+    fn keys() {
+        let map = FlurryHashMap::<usize, usize>::new();
+
+        map.insert(1, 42);
+        map.insert(2, 84);
+
+        let guard = epoch::pin();
+        assert_eq!(
+            map.keys(&guard).collect::<HashSet<&usize>>(),
+            HashSet::from_iter(vec![&1, &2])
+        );
+    }
+
+    #[test]
+    fn values() {
+        let map = FlurryHashMap::<usize, usize>::new();
+
+        map.insert(1, 42);
+        map.insert(2, 84);
+
+        let guard = epoch::pin();
+        assert_eq!(
+            map.values(&guard).collect::<HashSet<&usize>>(),
+            HashSet::from_iter(vec![&42, &84])
+        );
+    }
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,2 +1,4 @@
+mod iter;
 mod traverser;
+pub use iter::{Iter, Keys, Values};
 pub(crate) use traverser::NodeIter;

--- a/tests/jdk/map_check.rs
+++ b/tests/jdk/map_check.rs
@@ -66,6 +66,42 @@ where
     assert_eq!(sum, k1.len());
 }
 
+fn ittest1<K>(map: &FlurryHashMap<K, usize>, expect: usize)
+where
+    K: Sync + Send + Copy + Hash + Eq,
+{
+    let mut sum = 0;
+    let guard = epoch::pin();
+    for _ in map.keys(&guard) {
+        sum += 1;
+    }
+    assert_eq!(sum, expect);
+}
+
+fn ittest2<K>(map: &FlurryHashMap<K, usize>, expect: usize)
+where
+    K: Sync + Send + Copy + Hash + Eq,
+{
+    let mut sum = 0;
+    let guard = epoch::pin();
+    for _ in map.values(&guard) {
+        sum += 1;
+    }
+    assert_eq!(sum, expect);
+}
+
+fn ittest3<K>(map: &FlurryHashMap<K, usize>, expect: usize)
+where
+    K: Sync + Send + Copy + Hash + Eq,
+{
+    let mut sum = 0;
+    let guard = epoch::pin();
+    for _ in map.iter(&guard) {
+        sum += 1;
+    }
+    assert_eq!(sum, expect);
+}
+
 #[test]
 fn everything() {
     let mut rng = rand::thread_rng();
@@ -90,4 +126,9 @@ fn everything() {
     t1(&map, &keys[..], SIZE);
     // get (absent)
     t1(&map, &absent_keys[..], 0);
+
+    // iter, keys, values (present)
+    ittest1(&map, SIZE);
+    ittest2(&map, SIZE);
+    ittest3(&map, SIZE);
 }

--- a/tests/jdk/map_check.rs
+++ b/tests/jdk/map_check.rs
@@ -37,6 +37,35 @@ where
     assert_eq!(sum, expect);
 }
 
+fn t4<K>(map: &FlurryHashMap<K, usize>, keys: &[K], expect: usize)
+where
+    K: Sync + Send + Copy + Hash + Eq,
+{
+    let mut sum = 0;
+    for i in 0..keys.len() {
+        if map.contains_key(&keys[i]) {
+            sum += 1;
+        }
+    }
+    assert_eq!(sum, expect);
+}
+
+fn t7<K>(map: &FlurryHashMap<K, usize>, k1: &[K], k2: &[K])
+where
+    K: Sync + Send + Copy + Hash + Eq,
+{
+    let mut sum = 0;
+    for i in 0..k1.len() {
+        if map.contains_key(&k1[i]) {
+            sum += 1;
+        }
+        if map.contains_key(&k2[i]) {
+            sum += 1;
+        }
+    }
+    assert_eq!(sum, k1.len());
+}
+
 #[test]
 fn everything() {
     let mut rng = rand::thread_rng();
@@ -51,6 +80,12 @@ fn everything() {
     t3(&map, &keys[..], SIZE);
     // put (present)
     t3(&map, &keys[..], 0);
+    // contains_key (present & absent)
+    t7(&map, &keys[..], &absent_keys[..]);
+    // contains_key (present)
+    t4(&map, &keys[..], SIZE);
+    // contains_key (absent)
+    t4(&map, &absent_keys[..], 0);
     // get (present)
     t1(&map, &keys[..], SIZE);
     // get (absent)


### PR DESCRIPTION
I was following part of you stream earlier today and decided to try my hand at porting some of the other Java tests from [MapCheck.java](https://hg.openjdk.java.net/jdk/jdk/file/345266000aba/test/jdk/java/util/concurrent/ConcurrentHashMap/MapCheck.java).

The contains_key tests were pretty straightforward since you already implemented `contains_key`. Those are `t4` and `t7`.

During the stream, you mentioned that `NodeIter` is a private Iterator which could be the basis for public iterators on keys, values, and entries. I've done that in a new file `src/iter/iter.rs` with three new structs `Iter`, `Keys`, and `Values` (similar to `std::collections::HashMap`). I added some of my own tests for the new `iter()`, `keys()`, and `values()` methods and ported `ittest1`, `ittest2`, and `ittest3` from MapCheck.java.

To get the values out of the `NodeIter`, I had to add two more unsafe blocks.

I'm still a noob at concurrency and Rust so let me know if there's anything to improve here. I'm using this as a learning experience. Thanks for streaming!