### PR TITLE
Add cargo deny checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,11 +8,25 @@ jobs:
    pool:
      vmImage: ubuntu-16.04
    steps:
+     # Work around https://github.com/microsoft/azure-pipelines-tasks/issues/12179
+     - bash: |
+         sudo rm -r /usr/share/rust/.cargo/bin
+       displayName: Remove .cargo/bin so we can restore it from cache
+     - task: Cache@2
+       inputs:
+         key: cargo-deny | $(Agent.OS)
+         path: /usr/share/rust/.cargo/bin
+         cacheHitVar: CACHE_RESTORED
+     - bash: |
+         find -D exec /usr/share/rust/.cargo/bin ! -name 'cargo-deny' -type f -exec rm {} +
+       displayName: Only rely on cached cargo-deny
+       condition: eq(variables.CACHE_RESTORED, 'true')
      - template: install-rust.yml@templates
        parameters:
          rust: stable
      - script: cargo install cargo-deny
        displayName: install cargo-deny
+       condition: ne(variables.CACHE_RESTORED, 'true')
      - script: cargo deny check
        displayName: cargo deny
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,18 @@ jobs:
    parameters:
      codecov_token: $(CODECOV_TOKEN_SECRET)
      minrust: 1.36.0 # parking_lot 0.10
+ - job: deny
+   displayName: "Disallowed attributes"
+   pool:
+     vmImage: ubuntu-16.04
+   steps:
+     - template: install-rust.yml@templates
+       parameters:
+         rust: stable
+     - script: cargo install cargo-deny
+       displayName: install cargo-deny
+     - script: cargo deny check
+       displayName: cargo deny
 
 resources:
   repositories:

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,39 @@
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-url = "https://github.com/rustsec/advisory-db"
+vulnerability = "deny"
+unmaintained = "warn"
+notice = "warn"
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+allow = []
+deny = []
+copyleft = "warn"
+allow-osi-fsf-free = "either"
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+highlight = "all"
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-git = []


### PR DESCRIPTION
Check that we don't depend on vulnerable crate versions, have duplicates in our dependency graph, or depend on licenses that it's not okay for us to depend on.