### PR TITLE
Worked on some TODOs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,5 @@ maintenance = { status = "experimental" }
 crossbeam = "0.7"
 parking_lot = "0.10"
 rand = "0.7"
-lazy_static = "1.4.0"
 num_cpus = "1.12.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ maintenance = { status = "experimental" }
 crossbeam = "0.7"
 parking_lot = "0.10"
 rand = "0.7"
+lazy_static = "1.4.0"
+num_cpus = "1.12.0"
+

--- a/README.md
+++ b/README.md
@@ -36,12 +36,11 @@ want suggestions for how to proceed.
  - Implement the [`TreeNode` optimization] for large bins. Make sure you
    also read the [implementation notes][tree-impl] on that optimization
    in the big comment in the Java code.
- - Implement batch operations like `from_iter` and `extend`. Note the
-   effect on [initial capacity].
+ - Optimize the `FlurryHashMap::extend` method. Note the effect on 
+   [initial capacity].
  - Add (optional) serialization and deserialization support.
  - Provide methods that wrap `get`, `insert`, `remove`, and friends so
    that the user does not need to know about `Guard`.
- - Use `num_cpus` to choose resize stride [more intelligently][numcpu].
 
   [hashbrown-bench]: https://github.com/rust-lang/hashbrown/blob/master/benches/bench.rs
   [dashmap-bench]: https://github.com/xacrimon/dashmap/tree/master/benches


### PR DESCRIPTION
Pseudoimplemented batch operations and made it so that `num_cpus` is used to choose resize stride more intelligently.

Implemented `std::iter::FromIterator<(K, V)>` for `FlurryHashMap<K, V, _>` using the newly created `FlurryHashMap::extend` method.

The implementation of `FlurryHashMap::extend` is not efficient at all: it's intended to be a place holder for a more robust implementation. Nevertheless, now there's only one method missing an appropriate implementation (instead of two).