### PR TITLE
Fixed bug in `Node#find`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,12 +310,12 @@ where
 }
 
 impl<K, V, S: BuildHasher> FlurryHashMap<K, V, S> {
-    /// Creates an empty HashMap which will use the given hash builder to hash keys.
+    /// Creates an empty map which will use `hash_builder` to hash keys.
     ///
     /// The created map has the default initial capacity.
     ///
-    /// Warning: hash_builder is normally randomly generated, and is designed to
-    /// allow HashMaps to be resistant to attacks that cause many collisions and
+    /// Warning: `hash_builder` is normally randomly generated, and is designed to
+    /// allow the map to be resistant to attacks that cause many collisions and
     /// very poor performance. Setting it manually using this
     /// function can expose a DoS attack vector.
     pub fn with_hasher(hash_builder: S) -> Self {
@@ -329,12 +329,13 @@ impl<K, V, S: BuildHasher> FlurryHashMap<K, V, S> {
         }
     }
 
-    /// Creates an empty HashMap with the specified capacity, using hash_builder to hash the keys.
+    /// Creates an empty map with the specified `capacity`, using `hash_builder` to hash the keys.
     ///
-    /// The hash map will be able to hold at least capacity elements without reallocating. If
-    /// capacity is 0, the hash map will not allocate.
+    /// The map will be sized to accommodate `capacity` elements with a low chance of reallocating
+    /// (assuming uniformly distributed hashes). If `capacity` is 0, the call will not allocate,
+    /// and is equivalent to [`FlurryHashMap::new`].
     ///
-    /// Warning: hash_builder is normally randomly generated, and is designed to allow HashMaps
+    /// Warning: `hash_builder` is normally randomly generated, and is designed to allow the map
     /// to be resistant to attacks that cause many collisions and very poor performance.
     /// Setting it manually using this function can expose a DoS attack vector.
     pub fn with_capacity_and_hasher(hash_builder: S, n: usize) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ where
     }
 }
 
-impl<K, V, S> FlurryHashMap<K, V, S> {
+impl<K, V, S: BuildHasher> FlurryHashMap<K, V, S> {
     /// Creates a new, empty map with the default initial table size (16).
     /// It uses the given hasher, rather than the default `RandomState`.
     pub fn new_with_hasher(hasher: S) -> Self {

--- a/src/node.rs
+++ b/src/node.rs
@@ -61,7 +61,7 @@ where
                     };
 
                     if n.hash == hash && &n.key == key {
-                        break Shared::from(self as *const _);
+                        break Shared::from(node as *const _);
                     }
                     let next = n.next.load(Ordering::SeqCst, guard);
                     if next.is_null() {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -82,7 +82,7 @@ fn insert_in_same_bucket_and_get_distinct_entries() {
         }
     }
 
-    let map = FlurryHashMap::<usize, usize, _>::new_with_hasher(OneBucketState);
+    let map = FlurryHashMap::<usize, usize, _>::with_hasher(OneBucketState);
 
     map.insert(42, 0, &epoch::pin());
     map.insert(50, 20, &epoch::pin());

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -77,7 +77,9 @@ fn insert_in_same_bucket_and_get_distinct_entries() {
     }
     impl Hasher for OneBucketHasher {
         fn write(&mut self, _bytes: &[u8]) {}
-        fn finish(&self) -> u64 { 0 }
+        fn finish(&self) -> u64 {
+            0
+        }
     }
 
     let map = FlurryHashMap::<usize, usize, _>::new_with_hasher(OneBucketState);


### PR DESCRIPTION
It turns out that `find` would always return the first entry in a bucket, as longs as the desired entry was found somewhere in the bucket. This can be replicated by reverting the change in `lib/node.rs`.

At the same time, I added two new constructors of `FlurryHashMap`, which can take a custom **Hasher**: the architecture allowed other hashers to be used, but we couldn't actually build any `Flurry` instances beforehand.