### PR TITLE
Move rand to [dev-dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 crossbeam-epoch = "0.8"
 parking_lot = "0.10"
-rand = "0.7"
 num_cpus = "1.12.0"
+
+[dev-dependencies]
+rand = "0.7"


### PR DESCRIPTION
It's only used in a few tests, not in the crate proper.