### PR TITLE
Implement compute_if_present

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -534,7 +534,7 @@ where
 
     /// If the value for the specified `key` is present, attempts to
     /// compute a new mapping given the key and its current mapped value.
-    /// 
+    ///
     /// The new mapping is computed by the `remapping_function`, which may
     /// return `None` to signalize that the mapping should be removed.
     /// The entire method invocation is performed atomically.
@@ -627,7 +627,7 @@ where
                     // note that there can still be readers in the bin!
 
                     // TODO: TreeBin & ReservationNode
-                    
+
                     let mut delta = 0;
                     let mut bin_count = 1;
                     let mut p = bin;
@@ -653,11 +653,8 @@ where
                             let new_value = remapping_function(&n.key, current_value);
                             if let Some(value) = new_value {
                                 // safety: we own value and have never shared it
-                                let now_garbage = n.value.swap(
-                                    Owned::new(value),
-                                    Ordering::SeqCst,
-                                    guard,
-                                );
+                                let now_garbage =
+                                    n.value.swap(Owned::new(value), Ordering::SeqCst, guard);
                                 // NOTE: now_garbage == current_value
 
                                 // safety: need to guarantee that now_garbage is no longer

--- a/src/map.rs
+++ b/src/map.rs
@@ -713,8 +713,8 @@ where
 
                     // TODO: TREEIFY_THRESHOLD
 
-                    if old_val.is_none() {
-                        // increment count
+                    if delta != 0 {
+                        // decrement count
                         self.add_count(delta, Some(bin_count), guard);
                     }
                     guard.flush();

--- a/src/map.rs
+++ b/src/map.rs
@@ -695,6 +695,10 @@ where
                                     // or by setting the next node as the first BinEntry if there is no previous entry
                                     t.store_bin(bini, next);
                                 }
+
+                                // in either case, mark the BinEntry as garbage, since it was just removed
+                                // safety: see remove
+                                unsafe { guard.defer_destroy(p) };
                             }
                             break Some(current_value);
                         }

--- a/src/map.rs
+++ b/src/map.rs
@@ -652,9 +652,9 @@ where
                             // safety: since the value is present now, and we've held a guard from
                             // the beginning of the search, the value cannot be dropped until the
                             // next epoch, which won't arrive until after we drop our guard.
-                            let current_value = unsafe { current_value.deref() };
+                            let new_value =
+                                remapping_function(&n.key, unsafe { current_value.deref() });
 
-                            let new_value = remapping_function(&n.key, current_value);
                             if let Some(value) = new_value {
                                 let now_garbage =
                                     n.value.swap(Owned::new(value), Ordering::SeqCst, guard);
@@ -706,6 +706,7 @@ where
                                 // in either case, mark the BinEntry as garbage, since it was just removed
                                 // safety: see remove
                                 unsafe { guard.defer_destroy(p) };
+                                unsafe { guard.defer_destroy(current_value) };
                                 break None;
                             }
                         }

--- a/src/map.rs
+++ b/src/map.rs
@@ -532,6 +532,196 @@ where
         }
     }
 
+    /// Maps `key` to `value` in this table.
+    ///
+    /// The value can be retrieved by calling [`get`] with a key that is equal to the original key.
+    pub fn compute_if_present<'g, F>(
+        &'g self,
+        key: K,
+        remapping_function: F,
+        guard: &'g Guard,
+    ) -> Option<&'g V>
+    where
+        F: Fn(&K, &V) -> Option<V>,
+    {
+        let h = self.hash(&key);
+
+        let mut table = self.table.load(Ordering::SeqCst, guard);
+
+        // let mut node = Owned::new(BinEntry::Node(Node {
+        //     key,
+        //     value: Atomic::null(),
+        //     hash: h,
+        //     next: Atomic::null(),
+        //     lock: parking_lot::Mutex::new(()),
+        // }));
+
+        loop {
+            // safety: see argument below for !is_null case
+            if table.is_null() || unsafe { table.deref() }.len() == 0 {
+                table = self.init_table(guard);
+                continue;
+            }
+
+            // safety: table is a valid pointer.
+            //
+            // we are in one of three cases:
+            //
+            //  1. if table is the one we read before the loop, then we read it while holding the
+            //     guard, so it won't be dropped until after we drop that guard b/c the drop logic
+            //     only queues a drop for the next epoch after removing the table.
+            //
+            //  2. if table is read by init_table, then either we did a load, and the argument is
+            //     as for point 1. or, we allocated a table, in which case the earliest it can be
+            //     deallocated is in the next epoch. we are holding up the epoch by holding the
+            //     guard, so this deref is safe.
+            //
+            //  3. if table is set by a Moved node (below) through help_transfer, it will _either_
+            //     keep using `table` (which is fine by 1. and 2.), or use the `next_table` raw
+            //     pointer from inside the Moved. how do we know that that is safe?
+            //
+            //     we must demonstrate that if a Moved(t) is _read_, then t must still be valid.
+            //     FIXME
+            let t = unsafe { table.deref() };
+
+            let bini = t.bini(h);
+            let bin = t.bin(bini, guard);
+            if bin.is_null() {
+                // fast path -- bin is empty so key is not present
+                return None; // X?? break
+            }
+
+            // slow path -- bin is non-empty
+            // safety: bin is a valid pointer.
+            //
+            // there are two cases when a bin pointer is invalidated:
+            //
+            //  1. if the table was resized, bin is a move entry, and the resize has completed. in
+            //     that case, the table (and all its heads) will be dropped in the next epoch
+            //     following that.
+            //  2. if the table is being resized, bin may be swapped with a move entry. the old bin
+            //     will then be dropped in the following epoch after that happens.
+            //
+            // in both cases, we held the guard when we got the reference to the bin. if any such
+            // swap happened, it must have happened _after_ we read. since we did the read while
+            // pinning the epoch, the drop must happen in the _next_ epoch (i.e., the one that we
+            // are holding up by holding on to our guard).
+            match *unsafe { bin.deref() } {
+                BinEntry::Moved(next_table) => {
+                    table = self.help_transfer(table, next_table, guard);
+                }
+                BinEntry::Node(ref head) => {
+                    // bin is non-empty, need to link into it, so we must take the lock
+                    let head_lock = head.lock.lock();
+
+                    // need to check that this is _still_ the head
+                    let current_head = t.bin(bini, guard);
+                    if current_head != bin {
+                        // nope -- try again from the start
+                        continue;
+                    }
+
+                    // yes, it is still the head, so we can now "own" the bin
+                    // note that there can still be readers in the bin!
+
+                    // TODO: TreeBin & ReservationNode
+                    
+                    let mut delta = 0;
+                    let mut bin_count = 1;
+                    let mut p = bin;
+                    let mut pred: Shared<'_, BinEntry<K, V>> = Shared::null();
+
+                    let old_val = loop {
+                        // safety: we read the bin while pinning the epoch. a bin will never be
+                        // dropped until the next epoch after it is removed. since it wasn't
+                        // removed, and the epoch was pinned, that cannot be until after we drop
+                        // our guard.
+                        let n = unsafe { p.deref() }.as_node().unwrap();
+                        // TODO: This Ordering can probably be relaxed due to the Mutex
+                        let next = n.next.load(Ordering::SeqCst, guard);
+                        if n.hash == h && &n.key == &key {
+                            // the key already exists in the map!
+                            let current_value = head.value.load(Ordering::SeqCst, guard);
+
+                            // safety: since the value is present now, and we've held a guard from
+                            // the beginning of the search, the value cannot be dropped until the
+                            // next epoch, which won't arrive until after we drop our guard.
+                            let current_value = unsafe { current_value.deref() };
+
+                            let new_value = remapping_function(&key, current_value);
+                            //https://youtu.be/yQFWmGaFBjk?t=10800
+                            if let Some(value) = new_value {
+                                // safety: we own value and have never shared it
+                                let now_garbage = n.value.swap(
+                                    Owned::new(value),
+                                    Ordering::SeqCst,
+                                    guard,
+                                );
+                                // NOTE: now_garbage == current_value
+
+                                // safety: need to guarantee that now_garbage is no longer
+                                // reachable. more specifically, no thread that executes _after_
+                                // this line can ever get a reference to now_garbage.
+                                //
+                                // here are the possible cases:
+                                //
+                                //  - another thread already has a reference to now_garbage.
+                                //    they must have read it before the call to swap.
+                                //    because of this, that thread must be pinned to an epoch <=
+                                //    the epoch of our guard. since the garbage is placed in our
+                                //    epoch, it won't be freed until the _next_ epoch, at which
+                                //    point, that thread must have dropped its guard, and with it,
+                                //    any reference to the value.
+                                //  - another thread is about to get a reference to this value.
+                                //    they execute _after_ the swap, and therefore do _not_ get a
+                                //    reference to now_garbage (they get value instead). there are
+                                //    no other ways to get to a value except through its Node's
+                                //    `value` field (which is what we swapped), so freeing
+                                //    now_garbage is fine.
+                                unsafe { guard.defer_destroy(now_garbage) };
+                            } else {
+                                delta = -1;
+                                // remove the BinEntry containing the removed key value pair from the bucket
+                                if !pred.is_null() {
+                                    // either by changing the pointer of the previous BinEntry, if present
+                                    // safety: see remove
+                                    unsafe { pred.deref() }
+                                        .as_node()
+                                        .unwrap()
+                                        .next
+                                        .store(next, Ordering::SeqCst);
+                                } else {
+                                    // or by setting the next node as the first BinEntry if there is no previous entry
+                                    t.store_bin(bini, next);
+                                }
+                            }
+                            break Some(current_value);
+                        }
+
+                        pred = p;
+                        if next.is_null() {
+                            // we're at the end of the bin
+                            break None;
+                        }
+                        p = next;
+
+                        bin_count += 1;
+                    };
+                    drop(head_lock);
+
+                    // TODO: TREEIFY_THRESHOLD
+
+                    if old_val.is_none() {
+                        // increment count
+                        self.add_count(delta, Some(bin_count), guard);
+                    }
+                    guard.flush();
+                    return old_val;
+                }
+            }
+        }
+    }
+
     fn help_transfer<'g>(
         &'g self,
         table: Shared<'g, Table<K, V>>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -631,7 +631,7 @@ where
 
                     // TODO: TreeBin & ReservationNode
 
-                    let mut delta = 0;
+                    let mut removed_node = false;
                     let mut bin_count = 1;
                     let mut p = bin;
                     let mut pred: Shared<'_, BinEntry<K, V>> = Shared::null();
@@ -687,7 +687,7 @@ where
                                     n.value.load(Ordering::SeqCst, guard).deref()
                                 });
                             } else {
-                                delta = -1;
+                                removed_node = true;
                                 // remove the BinEntry containing the removed key value pair from the bucket
                                 if !pred.is_null() {
                                     // either by changing the pointer of the previous BinEntry, if present
@@ -720,11 +720,9 @@ where
                     };
                     drop(head_lock);
 
-                    // TODO: TREEIFY_THRESHOLD
-
-                    if delta != 0 {
+                    if removed_node {
                         // decrement count
-                        self.add_count(delta, Some(bin_count), guard);
+                        self.add_count(-1, Some(bin_count), guard);
                     }
                     guard.flush();
                     return new_val;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -139,7 +139,7 @@ fn compute_if_present() {
 
     let guard = epoch::pin();
     map.insert(42, 0, &guard);
-    let old = map.compute_if_present(42, |_, v| Some(v + 1), &guard);
+    let old = map.compute_if_present(&42, |_, v| Some(v + 1), &guard);
     assert_eq!(old, Some(&0));
     {
         let guard = epoch::pin();
@@ -153,7 +153,7 @@ fn compute_if_present_empty() {
     let map = HashMap::<usize, usize>::new();
 
     let guard = epoch::pin();
-    let old = map.compute_if_present(42, |_, v| Some(v + 1), &guard);
+    let old = map.compute_if_present(&42, |_, v| Some(v + 1), &guard);
     assert!(old.is_none());
     {
         let guard = epoch::pin();
@@ -167,7 +167,7 @@ fn compute_if_present_remove() {
 
     let guard = epoch::pin();
     map.insert(42, 0, &guard);
-    let old = map.compute_if_present(42, |_, _| None, &guard);
+    let old = map.compute_if_present(&42, |_, _| None, &guard);
     assert_eq!(old, Some(&0));
     {
         let guard = epoch::pin();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -139,8 +139,8 @@ fn compute_if_present() {
 
     let guard = epoch::pin();
     map.insert(42, 0, &guard);
-    let old = map.compute_if_present(&42, |_, v| Some(v + 1), &guard);
-    assert_eq!(old, Some(&0));
+    let new = map.compute_if_present(&42, |_, v| Some(v + 1), &guard);
+    assert_eq!(new, Some(&1));
     {
         let guard = epoch::pin();
         let e = map.get(&42, &guard).unwrap();
@@ -153,8 +153,8 @@ fn compute_if_present_empty() {
     let map = HashMap::<usize, usize>::new();
 
     let guard = epoch::pin();
-    let old = map.compute_if_present(&42, |_, v| Some(v + 1), &guard);
-    assert!(old.is_none());
+    let new = map.compute_if_present(&42, |_, v| Some(v + 1), &guard);
+    assert!(new.is_none());
     {
         let guard = epoch::pin();
         assert!(map.get(&42, &guard).is_none());
@@ -167,8 +167,8 @@ fn compute_if_present_remove() {
 
     let guard = epoch::pin();
     map.insert(42, 0, &guard);
-    let old = map.compute_if_present(&42, |_, _| None, &guard);
-    assert_eq!(old, Some(&0));
+    let new = map.compute_if_present(&42, |_, _| None, &guard);
+    assert!(new.is_none());
     {
         let guard = epoch::pin();
         assert!(map.get(&42, &guard).is_none());
@@ -260,18 +260,16 @@ fn concurrent_compute_if_present() {
     let t1 = std::thread::spawn(move || {
         let guard = epoch::pin();
         for i in 0..64 {
-            if let Some(v) = map1.compute_if_present(&i, |_, _| None, &guard) {
-                assert_eq!(v, &i);
-            }
+            let new = map1.compute_if_present(&i, |_, _| None, &guard);
+            assert!(new.is_none());
         }
     });
     let map2 = map.clone();
     let t2 = std::thread::spawn(move || {
         let guard = epoch::pin();
         for i in 0..64 {
-            if let Some(v) = map2.compute_if_present(&i, |_, _| None, &guard) {
-                assert_eq!(v, &i);
-            }
+            let new = map2.compute_if_present(&i, |_, _| None, &guard);
+            assert!(new.is_none());
         }
     });
 


### PR DESCRIPTION
This pull request contains the compute_if_present method, which is the simplest one among the reservation-based methods mentioned in #12 since it does not require ReservationNodes.

I took most of the code from put and remove.
For now, I only added basic tests but I also want to port some of the Java tests.