### PR TITLE
retain method

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1273,8 +1273,8 @@ where
     ///
     /// This method force entry deletion even if if it is updated concurrently.
     pub fn retain_force<F>(&mut self, mut f: F)
-        where
-            F: FnMut(&K, &V) -> bool,
+    where
+        F: FnMut(&K, &V) -> bool,
     {
         let guard = epoch::pin();
         // removed selected keys

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -471,8 +471,10 @@ fn retain_all_true() {
 #[test]
 fn retain_some() {
     let mut map: HashMap<u32, u32> = (0..10).map(|x| (x, x)).collect();
+    let expected_map: HashMap<u32, u32> = (5..10).map(|x| (x, x)).collect();
     map.retain(|_, v| *v >= 5);
     assert_eq!(map.len(), 5);
+    assert_eq!(map, expected_map);
 }
 
 #[test]
@@ -485,6 +487,8 @@ fn retain_force_empty() {
 #[test]
 fn retain_force_some() {
     let mut map: HashMap<u32, u32> = (0..10).map(|x| (x, x)).collect();
+    let expected_map: HashMap<u32, u32> = (5..10).map(|x| (x, x)).collect();
     map.retain_force(|_, v| *v >= 5);
     assert_eq!(map.len(), 5);
+    assert_eq!(map, expected_map);
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -350,3 +350,32 @@ fn clone_map_filled() {
     map.insert("NewItem", 100, &epoch::pin());
     assert_ne!(&map, &cloned_map);
 }
+
+#[test]
+fn retain_empty() {
+    let mut map = HashMap::<&'static str, u32>::new();
+    map.retain(|_, _| false);
+    assert_eq!(map.len(), 0);
+}
+
+#[test]
+fn retain_all_false() {
+    let mut map : HashMap::<u32, u32> = (0..10 as u32).map(|x| (x, x)).collect();
+    map.retain(|_, _| false);
+    assert_eq!(map.len(), 0);
+}
+
+#[test]
+fn retain_all_true() {
+    let size = 10usize;
+    let mut map : HashMap::<usize, usize> = (0..size).map(|x| (x, x)).collect();
+    map.retain(|_, _| true);
+    assert_eq!(map.len(), size);
+}
+
+#[test]
+fn retain_some() {
+    let mut map : HashMap::<u32, u32> = (0..10).map(|x| (x, x)).collect();
+    map.retain(|_, v| *v >= 5);
+    assert_eq!(map.len(), 5);
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,4 +1,4 @@
-use crossbeam_epoch::{self as epoch, Shared};
+use crossbeam_epoch::{self as epoch};
 use flurry::*;
 use std::sync::Arc;
 
@@ -34,42 +34,6 @@ fn get_key_value_empty() {
         let guard = epoch::pin();
         let e = map.get_key_value(&42, &guard);
         assert!(e.is_none());
-    }
-}
-
-#[test]
-fn replace_empty() {
-    let map = HashMap::<usize, usize>::new();
-
-    {
-        let guard = epoch::pin();
-        let old = map.replace_node(&42, None, None, &guard);
-        assert!(old.is_none());
-    }
-}
-
-#[test]
-fn replace_existing() {
-    let map = HashMap::<usize, usize>::new();
-    {
-        let guard = epoch::pin();
-        map.insert(42, 42, &guard);
-        let old = map.replace_node(&42, Some(10), None, &guard);
-        assert!(old.is_none());
-        assert_eq!(*map.get(&42, &guard).unwrap(), 10);
-    }
-}
-
-#[test]
-fn replace_old_value_non_matching() {
-    let map = HashMap::<usize, usize>::new();
-    {
-        let guard = epoch::pin();
-        map.insert(42, 42, &guard);
-        // TODO: fit test with an actual non valid old_value
-        let old = map.replace_node(&42, None, None, &guard);
-        assert!(old.is_none());
-        assert_eq!(*map.get(&42, &guard).unwrap(), 42);
     }
 }
 
@@ -396,7 +360,7 @@ fn retain_empty() {
 
 #[test]
 fn retain_all_false() {
-    let mut map : HashMap::<u32, u32> = (0..10 as u32).map(|x| (x, x)).collect();
+    let mut map: HashMap<u32, u32> = (0..10 as u32).map(|x| (x, x)).collect();
     map.retain(|_, _| false);
     assert_eq!(map.len(), 0);
 }
@@ -404,14 +368,28 @@ fn retain_all_false() {
 #[test]
 fn retain_all_true() {
     let size = 10usize;
-    let mut map : HashMap::<usize, usize> = (0..size).map(|x| (x, x)).collect();
+    let mut map: HashMap<usize, usize> = (0..size).map(|x| (x, x)).collect();
     map.retain(|_, _| true);
     assert_eq!(map.len(), size);
 }
 
 #[test]
 fn retain_some() {
-    let mut map : HashMap::<u32, u32> = (0..10).map(|x| (x, x)).collect();
+    let mut map: HashMap<u32, u32> = (0..10).map(|x| (x, x)).collect();
     map.retain(|_, v| *v >= 5);
+    assert_eq!(map.len(), 5);
+}
+
+#[test]
+fn retain_force_empty() {
+    let mut map = HashMap::<&'static str, u32>::new();
+    map.retain_force(|_, _| false);
+    assert_eq!(map.len(), 0);
+}
+
+#[test]
+fn retain_force_some() {
+    let mut map: HashMap<u32, u32> = (0..10).map(|x| (x, x)).collect();
+    map.retain_force(|_, v| *v >= 5);
     assert_eq!(map.len(), 5);
 }


### PR DESCRIPTION
Implemented `retain` for HashMap
Implemented `retain` tests for empty map, retain all elements, retain none elements and retain arbitrary elements