### PR TITLE
Add test which attempts to encounter a concurrent resize and retrieval

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -162,6 +162,16 @@ mod tests {
         }
     }
 
+    fn drop_entry(entry: BinEntry<usize, usize>) {
+        // currently bins don't handle dropping their
+        // own values the Table is responsible. This
+        // makes use of the tables implementation for
+        // convenience in the unit test
+        let mut table = Table::<usize, usize>::new(1);
+        table.store_bin(0, Owned::new(entry));
+        table.drop_bins();
+    }
+
     #[test]
     fn find_node_no_match() {
         let guard = &crossbeam_epoch::pin();
@@ -171,6 +181,7 @@ mod tests {
         node1.next.store(Owned::new(entry2), Ordering::SeqCst);
         let entry1 = BinEntry::Node(node1);
         assert!(entry1.find(1, &0, guard).is_null());
+        drop_entry(entry1);
     }
 
     #[test]
@@ -184,6 +195,7 @@ mod tests {
                 .key,
             2
         );
+        drop_entry(entry);
     }
 
     #[test]
@@ -201,6 +213,7 @@ mod tests {
                 .key,
             5
         );
+        drop_entry(entry1);
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -146,3 +146,102 @@ pub(crate) struct Node<K, V> {
     pub(crate) next: Atomic<BinEntry<K, V>>,
     pub(crate) lock: Mutex<()>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossbeam_epoch::Owned;
+
+    fn new_node(hash: u64, key: usize, value: usize) -> Node<usize, usize> {
+        Node {
+            hash,
+            key,
+            value: Atomic::new(value),
+            next: Atomic::null(),
+            lock: Mutex::new(()),
+        }
+    }
+
+    #[test]
+    fn find_node_no_match() {
+        let guard = &crossbeam_epoch::pin();
+        let node2 = new_node(4, 5, 6);
+        let entry2 = BinEntry::Node(node2);
+        let node1 = new_node(1, 2, 3);
+        node1.next.store(Owned::new(entry2), Ordering::SeqCst);
+        let entry1 = BinEntry::Node(node1);
+        assert!(entry1.find(1, &0, guard).is_null());
+    }
+
+    #[test]
+    fn find_node_single_match() {
+        let guard = &crossbeam_epoch::pin();
+        let entry = BinEntry::Node(new_node(1, 2, 3));
+        assert_eq!(
+            unsafe { entry.find(1, &2, guard).deref() }
+                .as_node()
+                .unwrap()
+                .key,
+            2
+        );
+    }
+
+    #[test]
+    fn find_node_multi_match() {
+        let guard = &crossbeam_epoch::pin();
+        let node2 = new_node(4, 5, 6);
+        let entry2 = BinEntry::Node(node2);
+        let node1 = new_node(1, 2, 3);
+        node1.next.store(Owned::new(entry2), Ordering::SeqCst);
+        let entry1 = BinEntry::Node(node1);
+        assert_eq!(
+            unsafe { entry1.find(4, &5, guard).deref() }
+                .as_node()
+                .unwrap()
+                .key,
+            5
+        );
+    }
+
+    #[test]
+    fn find_moved_empty_bins_no_match() {
+        let guard = &crossbeam_epoch::pin();
+        let table = &Table::<usize, usize>::new(1);
+        let entry = BinEntry::<usize, usize>::Moved(table as *const _);
+        assert!(entry.find(1, &2, guard).is_null());
+    }
+
+    #[test]
+    fn find_moved_no_bins_no_match() {
+        let guard = &crossbeam_epoch::pin();
+        let table = &Table::<usize, usize>::new(0);
+        let entry = BinEntry::<usize, usize>::Moved(table as *const _);
+        assert!(entry.find(1, &2, guard).is_null());
+    }
+
+    #[test]
+    fn find_moved_null_bin_no_match() {
+        let guard = &crossbeam_epoch::pin();
+        let table = &mut Table::<usize, usize>::new(2);
+        table.store_bin(1, Owned::new(BinEntry::Node(new_node(1, 2, 3))));
+        let entry = BinEntry::<usize, usize>::Moved(table as *const _);
+        assert!(entry.find(0, &1, guard).is_null());
+        table.drop_bins();
+    }
+
+    #[test]
+    fn find_moved_match() {
+        let guard = &crossbeam_epoch::pin();
+        let table = &mut Table::<usize, usize>::new(1);
+        table.store_bin(0, Owned::new(BinEntry::Node(new_node(1, 2, 3))));
+        let entry = BinEntry::<usize, usize>::Moved(table as *const _);
+        assert_eq!(
+            unsafe { entry.find(1, &2, guard).deref() }
+                .as_node()
+                .unwrap()
+                .key,
+            2
+        );
+        table.drop_bins();
+    }
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -245,11 +245,10 @@ fn concurrent_resize_and_get() {
     }
 
     let map1 = map.clone();
-    // t1 is inserting a lot of new keys, triggering resizes
+    // t1 is using reserve to trigger a bunch of resizes
     let t1 = std::thread::spawn(move || {
-        let guard = epoch::pin();
-        for i in 32..1024 {
-            assert!(map1.insert(i, i, &guard).is_none());
+        for power in 0..16 {
+            map1.reserve(1 << power);
         }
     });
     let map2 = map.clone();
@@ -266,12 +265,6 @@ fn concurrent_resize_and_get() {
 
     t1.join().unwrap();
     t2.join().unwrap();
-
-    let guard = epoch::pin();
-    for i in 0..1024 {
-        let (k, v) = map.get_key_value(&i, &guard).unwrap();
-        assert_eq!(k, v);
-    }
 }
 
 #[test]


### PR DESCRIPTION
I noticed that one of the areas of the code which had low test coverage was the [BinEntry::Moved branch in node.rs](https://github.com/jonhoo/flurry/blob/master/src/node.rs#L107). This test is designed to exercise that codepath. At least on my machine it seems to exercise the codepath but it is non-deterministic whether it will actually encounter the path.