### PR TITLE
Fix broken doclinks which are causing the docs to fail to build.

### DIFF
--- a/src/iter/iter.rs
+++ b/src/iter/iter.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::Ordering;
 
 /// An iterator over a map's entries.
 ///
-/// See [`HashMap::iter`] for details.
+/// See [`HashMap::iter`](crate::HashMap::iter) for details.
 #[derive(Debug)]
 pub struct Iter<'g, K, V> {
     pub(crate) node_iter: NodeIter<'g, K, V>,
@@ -24,7 +24,7 @@ impl<'g, K, V> Iterator for Iter<'g, K, V> {
 
 /// An iterator over a map's keys.
 ///
-/// See [`HashMap::keys`] for details.
+/// See [`HashMap::keys`](crate::HashMap::keys) for details.
 #[derive(Debug)]
 pub struct Keys<'g, K, V> {
     pub(crate) node_iter: NodeIter<'g, K, V>,
@@ -40,7 +40,7 @@ impl<'g, K, V> Iterator for Keys<'g, K, V> {
 
 /// An iterator over a map's values.
 ///
-/// See [`HashMap::values`] for details.
+/// See [`HashMap::values`](crate::HashMap::values) for details.
 #[derive(Debug)]
 pub struct Values<'g, K, V> {
     pub(crate) node_iter: NodeIter<'g, K, V>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,10 @@
 //! Operations that inspect the map as a whole, rather than a single key, operate on a snapshot of
 //! the underlying table. For example, iterators return elements reflecting the state of the hash
 //! table at some point at or since the creation of the iterator. Aggregate status methods like
-//! [`size`](HashMap::size) are typically useful only when a map is not undergoing concurrent
+//! [`len`](HashMap::len) are typically useful only when a map is not undergoing concurrent
 //! updates in other threads. Otherwise the results of these methods reflect transient states that
 //! may be adequate for monitoring or estimation purposes, but not for program control.
-//! Similarly, [`Clone`](HashMap::clone) may not produce a "perfect" clone if the underlying
+//! Similarly, [`Clone`](std::clone::Clone) may not produce a "perfect" clone if the underlying
 //! map is being concurrently modified.
 //!
 //! # Resizing behavior

--- a/src/map.rs
+++ b/src/map.rs
@@ -341,7 +341,7 @@ where
     #[inline]
     /// Maps `key` to `value` in this table.
     ///
-    /// The value can be retrieved by calling [`get`] with a key that is equal to the original key.
+    /// The value can be retrieved by calling [`HashMap::get`] with a key that is equal to the original key.
     pub fn insert<'g>(&'g self, key: K, value: V, guard: &'g Guard) -> Option<&'g V> {
         self.put(key, value, false, guard)
     }


### PR DESCRIPTION
Currently, docs.rs is broken for flurry: https://docs.rs/crate/flurry/0.0.2/builds/215675. This PR fixes it.

I think it would probably be a good idea to fail the build if doclinks are broken. However, I'm not familiar with azure-pipelines, so I'm not entirely sure how to set this up.