### PR TITLE
Steal good commits from #44

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ crossbeam-epoch = "0.9"
 parking_lot = "0.10"
 num_cpus = "1.12.0"
 
+[dependencies.ahash]
+version = "0.3.2"
+default-features = false
+
 [dev-dependencies]
 rand = "0.7"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@
 #![deny(
     missing_docs,
     missing_debug_implementations,
+    unreachable_pub,
     intra_doc_link_resolution_failure
 )]
 #![warn(rust_2018_idioms)]
@@ -208,6 +209,9 @@ mod raw;
 pub mod iter;
 
 pub use map::HashMap;
+
+/// Default hasher for [`HashMap`].
+pub type DefaultHashBuilder = ahash::RandomState;
 
 /// Types needed to safely access shared data concurrently.
 pub mod epoch {

--- a/src/map.rs
+++ b/src/map.rs
@@ -3,7 +3,6 @@ use crate::node::*;
 use crate::raw::*;
 use crossbeam_epoch::{self as epoch, Atomic, Guard, Owned, Shared};
 use std::borrow::Borrow;
-use std::collections::hash_map::RandomState;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::iter::FromIterator;
@@ -61,7 +60,7 @@ macro_rules! load_factor {
 /// A concurrent hash table.
 ///
 /// See the [crate-level documentation](index.html) for details.
-pub struct HashMap<K, V, S = RandomState> {
+pub struct HashMap<K, V, S = crate::DefaultHashBuilder> {
     /// The array of bins. Lazily initialized upon first insertion.
     /// Size is always a power of two. Accessed directly by iterators.
     table: Atomic<Table<K, V>>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -11,18 +11,14 @@ use std::sync::{
     Once,
 };
 
-macro_rules! isize_bits {
-    () => {
-        std::mem::size_of::<isize>() * 8
-    };
-}
+const ISIZE_BITS: usize = core::mem::size_of::<isize>() * 8;
 
 /// The largest possible table capacity.  This value must be
 /// exactly 1<<30 to stay within Java array allocation and indexing
 /// bounds for power of two table sizes, and is further required
 /// because the top two bits of 32bit hash fields are used for
 /// control purposes.
-const MAXIMUM_CAPACITY: usize = 1 << 30; // TODO: use isize_bits!()
+const MAXIMUM_CAPACITY: usize = 1 << 30; // TODO: use ISIZE_BITS
 
 /// The default initial table capacity.  Must be a power of 2
 /// (i.e., at least 1) and at most `MAXIMUM_CAPACITY`.
@@ -37,15 +33,15 @@ const MIN_TRANSFER_STRIDE: isize = 16;
 
 /// The number of bits used for generation stamp in `size_ctl`.
 /// Must be at least 6 for 32bit arrays.
-const RESIZE_STAMP_BITS: usize = isize_bits!() / 2;
+const RESIZE_STAMP_BITS: usize = ISIZE_BITS / 2;
 
 /// The maximum number of threads that can help resize.
 /// Must fit in `32 - RESIZE_STAMP_BITS` bits for 32 bit architectures
 /// and `64 - RESIZE_STAMP_BITS` bits for 64 bit architectures
-const MAX_RESIZERS: isize = (1 << (isize_bits!() - RESIZE_STAMP_BITS)) - 1;
+const MAX_RESIZERS: isize = (1 << (ISIZE_BITS - RESIZE_STAMP_BITS)) - 1;
 
 /// The bit shift for recording size stamp in `size_ctl`.
-const RESIZE_STAMP_SHIFT: usize = isize_bits!() - RESIZE_STAMP_BITS;
+const RESIZE_STAMP_SHIFT: usize = ISIZE_BITS - RESIZE_STAMP_BITS;
 
 static NCPU_INITIALIZER: Once = Once::new();
 static NCPU: AtomicUsize = AtomicUsize::new(0);

--- a/src/map.rs
+++ b/src/map.rs
@@ -85,30 +85,32 @@ pub struct HashMap<K, V, S = RandomState> {
     build_hasher: S,
 }
 
-impl<K, V> Default for HashMap<K, V, RandomState>
+impl<K, V, S> Default for HashMap<K, V, S>
 where
     K: Sync + Send + Clone + Hash + Eq,
     V: Sync + Send,
+    S: BuildHasher + Default,
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<K, V> HashMap<K, V, RandomState>
+impl<K, V, S> HashMap<K, V, S>
 where
     K: Sync + Send + Clone + Hash + Eq,
     V: Sync + Send,
+    S: BuildHasher + Default,
 {
     /// Creates a new, empty map with the default initial table size (16).
     pub fn new() -> Self {
-        Self::with_hasher(RandomState::new())
+        Self::with_hasher(S::default())
     }
 
     /// Creates a new, empty map with an initial table size accommodating the specified number of
     /// elements without the need to dynamically resize.
     pub fn with_capacity(n: usize) -> Self {
-        Self::with_capacity_and_hasher(RandomState::new(), n)
+        Self::with_capacity_and_hasher(S::default(), n)
     }
 }
 
@@ -1448,10 +1450,11 @@ where
     }
 }
 
-impl<K, V> FromIterator<(K, V)> for HashMap<K, V, RandomState>
+impl<K, V, S> FromIterator<(K, V)> for HashMap<K, V, S>
 where
     K: Sync + Send + Clone + Hash + Eq,
     V: Sync + Send,
+    S: BuildHasher + Default,
 {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
         let mut iter = iter.into_iter();
@@ -1473,10 +1476,11 @@ where
     }
 }
 
-impl<'a, K, V> FromIterator<(&'a K, &'a V)> for HashMap<K, V, RandomState>
+impl<'a, K, V, S> FromIterator<(&'a K, &'a V)> for HashMap<K, V, S>
 where
     K: Sync + Send + Copy + Hash + Eq,
     V: Sync + Send + Copy,
+    S: BuildHasher + Default,
 {
     #[inline]
     fn from_iter<T: IntoIterator<Item = (&'a K, &'a V)>>(iter: T) -> Self {
@@ -1484,10 +1488,11 @@ where
     }
 }
 
-impl<'a, K, V> FromIterator<&'a (K, V)> for HashMap<K, V, RandomState>
+impl<'a, K, V, S> FromIterator<&'a (K, V)> for HashMap<K, V, S>
 where
     K: Sync + Send + Copy + Hash + Eq,
     V: Sync + Send + Copy,
+    S: BuildHasher + Default,
 {
     #[inline]
     fn from_iter<T: IntoIterator<Item = &'a (K, V)>>(iter: T) -> Self {
@@ -1549,6 +1554,7 @@ fn capacity() {
     // The table has been resized once (and it's capacity doubled),
     // since we inserted more elements than it can hold
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -368,7 +368,7 @@ fn get_and() {
     let guard = epoch::pin();
     map.insert(42, 32, &guard);
 
-    assert_eq!(map.get_and(&42, |value| *value + 10), Some(42));
+    assert_eq!(map.get_and(&42, |value| *value + 10, &guard), Some(42));
 }
 
 #[test]
@@ -448,47 +448,53 @@ fn from_iter_empty() {
 
 #[test]
 fn retain_empty() {
+    let guard = epoch::pin();
     let map = HashMap::<&'static str, u32>::new();
-    map.retain(|_, _| false);
+    map.retain(|_, _| false, &guard);
     assert_eq!(map.len(), 0);
 }
 
 #[test]
 fn retain_all_false() {
+    let guard = epoch::pin();
     let map: HashMap<u32, u32> = (0..10 as u32).map(|x| (x, x)).collect();
-    map.retain(|_, _| false);
+    map.retain(|_, _| false, &guard);
     assert_eq!(map.len(), 0);
 }
 
 #[test]
 fn retain_all_true() {
     let size = 10usize;
+    let guard = epoch::pin();
     let map: HashMap<usize, usize> = (0..size).map(|x| (x, x)).collect();
-    map.retain(|_, _| true);
+    map.retain(|_, _| true, &guard);
     assert_eq!(map.len(), size);
 }
 
 #[test]
 fn retain_some() {
+    let guard = epoch::pin();
     let map: HashMap<u32, u32> = (0..10).map(|x| (x, x)).collect();
     let expected_map: HashMap<u32, u32> = (5..10).map(|x| (x, x)).collect();
-    map.retain(|_, v| *v >= 5);
+    map.retain(|_, v| *v >= 5, &guard);
     assert_eq!(map.len(), 5);
     assert_eq!(map, expected_map);
 }
 
 #[test]
 fn retain_force_empty() {
+    let guard = epoch::pin();
     let map = HashMap::<&'static str, u32>::new();
-    map.retain_force(|_, _| false);
+    map.retain_force(|_, _| false, &guard);
     assert_eq!(map.len(), 0);
 }
 
 #[test]
 fn retain_force_some() {
+    let guard = epoch::pin();
     let map: HashMap<u32, u32> = (0..10).map(|x| (x, x)).collect();
     let expected_map: HashMap<u32, u32> = (5..10).map(|x| (x, x)).collect();
-    map.retain_force(|_, v| *v >= 5);
+    map.retain_force(|_, v| *v >= 5, &guard);
     assert_eq!(map.len(), 5);
     assert_eq!(map, expected_map);
 }

--- a/tests/jdk/map_check.rs
+++ b/tests/jdk/map_check.rs
@@ -57,8 +57,9 @@ where
     K: Sync + Send + Copy + Hash + Eq,
 {
     let mut sum = 0;
+    let guard = epoch::pin();
     for i in 0..keys.len() {
-        if map.contains_key(&keys[i]) {
+        if map.contains_key(&keys[i], &guard) {
             sum += 1;
         }
     }
@@ -86,11 +87,12 @@ where
     K: Sync + Send + Copy + Hash + Eq,
 {
     let mut sum = 0;
+    let guard = epoch::pin();
     for i in 0..k1.len() {
-        if map.contains_key(&k1[i]) {
+        if map.contains_key(&k1[i], &guard) {
             sum += 1;
         }
-        if map.contains_key(&k2[i]) {
+        if map.contains_key(&k2[i], &guard) {
             sum += 1;
         }
     }

--- a/tests/jsr166.rs
+++ b/tests/jsr166.rs
@@ -7,7 +7,7 @@ const ITER: [(usize, &'static str); 5] = [(1, "A"), (2, "B"), (3, "C"), (4, "D")
 fn test_from_iter() {
     let guard = unsafe { crossbeam_epoch::unprotected() };
     let map1 = from_iter_contron();
-    let map2 = HashMap::from_iter(ITER.iter());
+    let map2: HashMap<_, _> = HashMap::from_iter(ITER.iter());
 
     // TODO: improve when `Map: Eq`
     let mut fst: Vec<_> = map1.iter(&guard).collect();

--- a/tests/jsr166.rs
+++ b/tests/jsr166.rs
@@ -56,5 +56,5 @@ fn test_remove() {
     map.remove(&5, &guard);
     // TODO: add len check once method exists
     // assert_eq!(map.len(), 4);
-    assert!(!map.contains_key(&5));
+    assert!(!map.contains_key(&5, &guard));
 }


### PR DESCRIPTION
This steals a bunch of the commits from #44 that are _not_ related to `no_std`, and should land independently of whether we merge `no_std` support.