### PR TITLE
Use `clear()` in benchmarks

### DIFF
--- a/benches/flurry_hashbrown.rs
+++ b/benches/flurry_hashbrown.rs
@@ -51,14 +51,14 @@ macro_rules! bench_suite {
 macro_rules! bench_insert {
     ($group:ident, $keydist:expr, $bench_id: expr) => {
         $group.bench_function(BenchmarkId::from_parameter($bench_id), |b| {
+            let map: HashMap<_, _> = HashMap::with_capacity(SIZE as usize);
             b.iter(|| {
-                let mut map: HashMap<_, _> = HashMap::with_capacity(SIZE as usize);
-
                 let guard = epoch::pin();
+                map.clear(&guard);
                 ($keydist).take(SIZE).for_each(|i| {
                     map.insert(i, i, &guard);
                 });
-                black_box(&mut map);
+                black_box(&map);
             });
         });
     };


### PR DESCRIPTION
The benchmarks adapted from `hashbrown` introduced by #43 were missing the `clear()` method on the map and thus currently construct a new map every iteration. Now that we have `clear()` thanks to #42, we should fix this and make the benchmarks identical.