### PR TITLE
Share BinEntry::Moved across all moved bins in a table

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1197,7 +1197,7 @@ where
                     .cas_bin(
                         i,
                         Shared::null(),
-                        Owned::new(BinEntry::Moved(next_table as *const _)),
+                        table.get_moved(next_table as *const _, guard),
                         guard,
                     )
                     .is_ok();
@@ -1310,7 +1310,7 @@ where
 
                     next_table.store_bin(i, low_bin);
                     next_table.store_bin(i + n, high_bin);
-                    table.store_bin(i, Owned::new(BinEntry::Moved(next_table as *const _)));
+                    table.store_bin(i, table.get_moved(next_table as *const _, guard));
 
                     // everything up to last_run in the _old_ bin linked list is now garbage.
                     // those nodes have all been re-allocated in the new bin linked list.


### PR DESCRIPTION
This originates from #50 and tries to achieve performance improvements by instantiating only one `BinEntry::Moved` per table, as for all moved bins inside a table the `Moved` points to the same next table. In particular, this tries to reduce the amount of allocations of `Moved` by `Owned::new`, only `load`ing more shared pointers to the `Moved` instead.

This is submitted as a draft for the following reasons:

- ~~the history for this contains the changes in #55, which is still pending approval~~ (Edit: changed that)
- the previous implementation of `Table::drop` [contains a section](https://github.com/jonhoo/flurry/blob/b6b360feffa3ae6515739f6bf341fa27a7d0dc87/src/raw/mod.rs#L86-L98) which iterates through all bins, drops `Moved` entries and checks that none of the bins are non-empty. With these changes, the `Moved` is only dropped once (and turning all shared pointers to it `into_owned` would be incorrect), so this loop is not technically necessary any longer. I left the check against `Moved` in for now, but would like to discuss the possibility of removing it and relying on the other parts of the map implementation to uphold the invariant of all bins being empty at this point.
- I wanted to check against the results of sanitizer CI tests.
- in general, I want to give room for discussion on this.

I will add performance results to #50 as soon as I am done submitting this.