### PR TITLE
Fix santitizer for doctests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,12 +67,10 @@ jobs:
          rust: nightly
      - bash: |
            sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer
-           sed -i '/\[features\]/i [profile.dev]' Cargo.toml
-           sed -i '/profile.dev/a opt-level = 1' Cargo.toml
-           cat Cargo.toml
        displayName: Enable debug symbols
+     # only --lib --tests b/c of https://github.com/rust-lang/rust/issues/53945
      - script: |
-           env ASAN_OPTIONS="detect_odr_violation=0" RUSTFLAGS="-Z sanitizer=address" cargo test --features sanitize --target x86_64-unknown-linux-gnu
+           env ASAN_OPTIONS="detect_odr_violation=0" RUSTFLAGS="-Z sanitizer=address" cargo test --lib --tests --features sanitize --target x86_64-unknown-linux-gnu
        displayName: cargo -Z sanitizer=address test
  - job: lsan
    dependsOn: deny

--- a/src/map.rs
+++ b/src/map.rs
@@ -82,8 +82,7 @@ pub struct HashMap<K: 'static, V: 'static, S = crate::DefaultHashBuilder> {
     /// unsoundness as described in https://github.com/jonhoo/flurry/issues/46. Specifically, a
     /// user can do:
     ///
-    /// ```rust,ignore
-    /// # // this test should be should_panic, not ignore, but that makes ASAN crash..?
+    /// ```rust,should_panic
     /// # use flurry::HashMap;
     /// # use crossbeam_epoch;
     /// let map: HashMap<_, _> = HashMap::default();


### PR DESCRIPTION
This works around rust-lang/rust#53945 using the trick proposed in https://github.com/rust-lang/rust/issues/53945#issuecomment-426824324.