### PR TITLE
Prep for release of 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+
+### Changed
+
+### Removed
+
+## [0.1.0] - 2020-02-04
+### Added
+- First "real" release.
+
+[Unreleased]: https://github.com/jonhoo/inferno/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/jonhoo/inferno/compare/6cda7c8e7501b9b7453e7a2db269a994a99c0660...v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flurry"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2018"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ maintenance = { status = "experimental" }
 sanitize = ['crossbeam-epoch/sanitize']
 
 [dependencies]
-crossbeam-epoch = "0.9"
+crossbeam-epoch = "0.8"
 parking_lot = "0.10"
 num_cpus = "1.12.0"
 
@@ -44,5 +44,5 @@ harness = false
 name = "flurry_hashbrown" 
 harness = false
 
-[patch.crates-io]
-crossbeam-epoch = { git = "https://github.com/cynecx/crossbeam.git", branch = "fix-unsoundness" }
+# [patch.crates-io]
+# crossbeam-epoch = { git = "https://github.com/cynecx/crossbeam.git", branch = "fix-unsoundness" }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,20 +42,20 @@ jobs:
            - clippy
      - bash: cargo clippy --all-features -- -D warnings
        displayName: cargo clippy -- -D warnings
- - job: miri
-   displayName: "Run miri on test suite"
-   dependsOn: deny
-   pool:
-     vmImage: ubuntu-16.04
-   steps:
-     - template: install-rust.yml@templates
-       parameters:
-         rust: nightly
-         components:
-           - miri
-     # ignore leaks due to https://github.com/crossbeam-rs/crossbeam/issues/464
-     - bash: yes | cargo miri -Zmiri-ignore-leaks test
-       displayName: cargo miri test
+# - job: miri
+#   displayName: "Run miri on test suite"
+#   dependsOn: deny
+#   pool:
+#     vmImage: ubuntu-16.04
+#   steps:
+#     - template: install-rust.yml@templates
+#       parameters:
+#         rust: nightly
+#         components:
+#           - miri
+#     # ignore leaks due to https://github.com/crossbeam-rs/crossbeam/issues/464
+#     - bash: yes | cargo miri -Zmiri-ignore-leaks test
+#       displayName: cargo miri test
  - job: asan
    dependsOn: deny
    displayName: "Run address sanitizer on test suite"


### PR DESCRIPTION
This removes the patch that incorporates crossbeam-rs/crossbeam#458,
since that PR also bumps the version number, and 0.9 doesn't exist on
crates.io. This in turn means that the miri test has to be disabled for
this release in particular. I'll push a commit after release that
restores it and the crossbeam patch.

This commit also adds a changelog!