### PR TITLE
fix two typos in crate documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,8 +200,8 @@
 //! The Java implementation can rely on Java's runtime garbage collection to safely deallocate
 //! deleted or removed nodes, keys, and values. Since Rust does not have such a runtime, we must
 //! ensure through some other mechanism that we do not drop values before all references to them
-//! have goen away. We do this using [`crossbeam::epoch`], which provides an implementation of an
-//! epoch-based garbae collection scheme. This forces us to make certain API changes such as
+//! have gone away. We do this using [`crossbeam::epoch`], which provides an implementation of an
+//! epoch-based garbage collection scheme. This forces us to make certain API changes such as
 //! requiring `Guard` arguments to many methods or wrapping the return values, but provides much
 //! more efficient operation than if everything had to be atomically reference-counted.
 //!


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/flurry/71)
<!-- Reviewable:end -->
