### PR TITLE
Proper miri setup + pin miri nightly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,9 +47,12 @@ jobs:
    pool:
      vmImage: ubuntu-latest
    steps:
+     - bash: |
+         echo '##vso[task.setvariable variable=nightly]nightly-'$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+       displayName: "Determine latest miri nightly"
      - template: install-rust.yml@templates
        parameters:
-         rust: nightly
+         rust: $(nightly)
          components:
            - miri
      - script: cargo miri setup

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,8 +52,13 @@ jobs:
          rust: nightly
          components:
            - miri
-     # ignore leaks due to https://github.com/crossbeam-rs/crossbeam/issues/464
-     - bash: yes | cargo miri -Zmiri-ignore-leaks test
+     - script: cargo miri setup
+       displayName: cargo miri setup
+     # ignore leaks due to
+     # https://github.com/crossbeam-rs/crossbeam/issues/464
+     # which is
+     # https://github.com/rust-lang/miri/issues/940
+     - script: cargo miri -Zmiri-ignore-leaks test
        displayName: cargo miri test
  - job: asan
    dependsOn: deny


### PR DESCRIPTION
@RalfJung [suggested](https://github.com/jonhoo/flurry/commit/7bd22c62eac86a8e0d3426b5a4c790e9850e5843#r37880279) we use `cargo miri setup`, so we do. I've also pinned the nightly to one that has miri since the current nightly does not (https://github.com/rust-lang/rust/issues/70055).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/flurry/73)
<!-- Reviewable:end -->
