### PR TITLE
Do not free waker until safe

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -371,7 +371,11 @@ impl<K, V> TreeBin<K, V> {
                         // not obtain new references to our thread handle. Also,
                         // we just swapped out that handle, so it is no longer
                         // reachable.
-                        let _ = unsafe { waiter.into_owned() };
+                        //
+                        // Now, we cannot safely drop this _immediately_, since
+                        // we may have woken up and reached here _while_ some
+                        // was trying to wake us up, so we defer_destroy instead.
+                        unsafe { guard.defer_destroy(waiter) };
                     }
                     return;
                 }


### PR DESCRIPTION
It is possible for someone to try to wake a waiting thread while that
thread is spinning. In that case, the waiting thread may decide to free
its waker just before the waking thread tries to wake the waiting one,
resulting in a use-after-free.

This fixes that by deferring the freeing of the waker until the next
epoch.

Seems to fix #84.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/flurry/85)
<!-- Reviewable:end -->
