### PR TITLE
Bump major version of dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Bumped `parking_lot` to `0.11`
+- Bumped `ahash` to `0.4`
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ sanitize = ['crossbeam-epoch/sanitize']
 
 [dependencies]
 crossbeam-epoch = "0.8.2"
-parking_lot = "0.10"
+parking_lot = "0.11"
 num_cpus = "1.12.0"
 rayon = {version = "1.3", optional = true}
 serde = {version = "1.0.105", optional = true}
 
 [dependencies.ahash]
-version = "0.3.2"
+version = "0.4.0"
 default-features = false
 
 [dev-dependencies]


### PR DESCRIPTION
This is a breaking change since `ahash` is public through `DefaultHashBuilder`.

I wonder if we might want to wrap it in a newtype for the future?

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/flurry/92)
<!-- Reviewable:end -->
