### PR TITLE
Shared counters optimization #11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ sanitize = ['crossbeam-epoch/sanitize']
 crossbeam-epoch = "0.8.2"
 parking_lot = "0.10"
 num_cpus = "1.12.0"
+rand = { version = "0.7", features = ["small_rng"] }
 rayon = {version = "1.3", optional = true}
 serde = {version = "1.0.105", optional = true}
 
@@ -34,7 +35,6 @@ version = "0.3.2"
 default-features = false
 
 [dev-dependencies]
-rand = "0.7"
 rayon = "1.3"
 criterion = "0.3"
 serde_json = "1.0.50"

--- a/src/map.rs
+++ b/src/map.rs
@@ -1293,6 +1293,8 @@ where
                 .is_ok()
             {
                 // the selected counter cell had contention so we should increase the number of counter cells
+                // safety: only one thread can access this branch at a time so deref_mut should be safe.
+                // although i'm not sure, will update this safety message after someone confirms.
                 unsafe { self.counter_cells.load(Ordering::SeqCst, guard).deref_mut() }
                     .resize_with((n << 1) as usize, AtomicIsize::default);
                 self.cells_busy.store(false, Ordering::SeqCst);


### PR DESCRIPTION
Hello!

I've made an attempt at implementing the counter cell optimization. All of the tests currently pass, however this doesn't mean what I wrote works. I'm unsure how to test all branches when `count` experiences contention. 

I looked at the Java implementation and they use `ThreadLocalRandom`, as a counterpart I opted for `SmallRng`. According to the Java documentation it's not cryptographically secure, neither is `SmallRng`. Most of [`rand`'s generators](https://docs.rs/rand/0.8.4/rand/rngs/index.html#our-generators) are secure except for `StdRng` and `SmallRng`.

Also, in the Java version they initialize the array of `CounterCell`'s when `baseCount` experiences contention, however I figured the cost of initializing the array wouldn't be that high so it defaults to `vec![AtomicIsize::new(0), AtomicIsize::new(0)]` in `HashMap::with_hasher`.  

I'm opening this as a draft because ~~I might need to add tests (although I'm not sure how to test this)~~ a lot of the tests detect memory leaks (the capacity of the map isn't correct.) and I probably made plenty of mistakes. (this is my first open-source contribution)

Any feedback is greatly appreciated.

Fixes: #11 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/flurry/100)
<!-- Reviewable:end -->
