### PR TITLE
Fix references to Java source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
   [source file from JSR166]: http://gee.cs.oswego.edu/dl/concurrency-interest/index.html
-  [1.323]: http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/util/concurrent/ConcurrentHashMap.java?revision=1.323&view=markup
+  [1.323]: http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/jsr166/src/main/java/util/concurrent/ConcurrentHashMap.java?revision=1.323&view=markup
   [Rust API guidelines]: https://rust-lang.github.io/api-guidelines/necessities.html#crate-and-its-dependencies-have-a-permissive-license-c-permissive
   [live coding streams]: https://www.youtube.com/playlist?list=PLqbS7AVVErFj824-6QgnK_Za1187rNfnl
   [this tweet]: https://twitter.com/jonhoo/status/1194969578855714816

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 //! team](http://gee.cs.oswego.edu/dl/concurrency-interest/). Huge thanks to them for releasing the
 //! code into the public domain! Much of the documentation is also lifted from there. What follows
 //! is a slightly modified version of their implementation notes from within the [source
-//! file](http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/util/concurrent/ConcurrentHashMap.java?view=markup).
+//! file](http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/jsr166/src/main/java/util/concurrent/ConcurrentHashMap.java?view=markup).
 //!
 //! The primary design goal of this hash table is to maintain concurrent readability (typically
 //! method [`get`](HashMap::get), but also iterators and related methods) while minimizing update contention.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 //! team](http://gee.cs.oswego.edu/dl/concurrency-interest/). Huge thanks to them for releasing the
 //! code into the public domain! Much of the documentation is also lifted from there. What follows
 //! is a slightly modified version of their implementation notes from within the [source
-//! file](http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/jsr166/src/main/java/util/concurrent/ConcurrentHashMap.java?view=markup).
+//! file](http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/jsr166/src/main/java/util/concurrent/ConcurrentHashMap.java?revision=1.323&view=markup).
 //!
 //! The primary design goal of this hash table is to maintain concurrent readability (typically
 //! method [`get`](HashMap::get), but also iterators and related methods) while minimizing update contention.


### PR DESCRIPTION
Updates outdated references to source files.

Previously the link in `src/lib.rs` didn't include the revision, while `README.md` did. Was this intentional? 7fc19d97538434499ce93aba9e695eada69fd89c updates only the revision

It may be better to update the links to [an archive.org snapshot](https://web.archive.org/web/20221004094436/https://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/jsr166/src/main/java/util/concurrent/ConcurrentHashMap.java?revision=1.323&view=markup) instead

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/flurry/110)
<!-- Reviewable:end -->
