### PR TITLE
chore: fix typo in `retain_force` method doc

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -2686,7 +2686,7 @@ where
     ///
     /// In other words, remove all pairs `(k, v)` such that `f(&k,&v)` returns `false`.
     ///
-    /// This method always deletes any key/value pair that `f` returns `false` for, even if if the
+    /// This method always deletes any key/value pair that `f` returns `false` for, even if the
     /// value is updated concurrently. If you do not want that behavior, use [`HashMap::retain`].
     ///
     /// # Examples


### PR DESCRIPTION
Just noticed this when I was reading the `retain` docs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/flurry/125)
<!-- Reviewable:end -->
